### PR TITLE
Profile pins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ riderModule.iml
 *.sln.DotSettings.user
 /ProjectLighthouse/r/*
 /ProjectLighthouse/logs/*
+/ProjectLighthouse/ProjectLighthouse.csproj.user
+.vs/

--- a/.idea/.idea.ProjectLighthouse/.idea/.name
+++ b/.idea/.idea.ProjectLighthouse/.idea/.name
@@ -1,1 +1,0 @@
-ProjectLighthouse

--- a/ProjectLighthouse/Controllers/UserController.cs
+++ b/ProjectLighthouse/Controllers/UserController.cs
@@ -137,13 +137,13 @@ namespace LBPUnion.ProjectLighthouse.Controllers
             User user = await this.database.UserFromRequest(this.Request);
             if (user == null) return this.StatusCode(403, "");
 
-            string pinsText = await new System.IO.StreamReader(this.Request.Body).ReadToEndAsync();
-            Pins pinData = JsonSerializer.Deserialize<Pins>(pinsText);
+            string pinsString = await new System.IO.StreamReader(this.Request.Body).ReadToEndAsync();
+            Pins pinJson = JsonSerializer.Deserialize<Pins>(pinsString);
 
             // Sometimes the update gets called periodically as pin progress updates via playing,
             // may not affect equipped profile pins however, so check before setting it.
             string currentPins = user.Pins;
-            string newPins = string.Join(",", pinData.profile_pins);
+            string newPins = string.Join(",", pinJson.profile_pins);
             if (!String.Equals(currentPins,newPins)) {
                 user.Pins = newPins;
                 await this.database.SaveChangesAsync();

--- a/ProjectLighthouse/Controllers/UserController.cs
+++ b/ProjectLighthouse/Controllers/UserController.cs
@@ -143,7 +143,7 @@ namespace LBPUnion.ProjectLighthouse.Controllers
             // Sometimes the update gets called periodically as pin progress updates via playing,
             // may not affect equipped profile pins however, so check before setting it.
             string currentPins = user.Pins;
-            string newPins = string.Join(",", pinJson.profile_pins);
+            string newPins = string.Join(",", pinJson.ProfilePins);
             if (!String.Equals(currentPins,newPins)) {
                 user.Pins = newPins;
                 await this.database.SaveChangesAsync();

--- a/ProjectLighthouse/Controllers/UserController.cs
+++ b/ProjectLighthouse/Controllers/UserController.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Text.Json;
 using System.Xml;
 using LBPUnion.ProjectLighthouse.Types;
 using LBPUnion.ProjectLighthouse.Types.Profiles;
@@ -128,6 +129,27 @@ namespace LBPUnion.ProjectLighthouse.Controllers
 
             if (this.database.ChangeTracker.HasChanges()) await this.database.SaveChangesAsync(); // save the user to the database if we changed anything
             return this.Ok();
+        }
+
+        // Profile only right now
+        [HttpPost("update_my_pins")]
+        public async Task<IActionResult> UpdateMyPins()
+        {
+            User user = await this.database.UserFromRequest(this.Request);
+            if (user == null) return this.StatusCode(403, "");
+
+            string pinsText = await new System.IO.StreamReader(this.Request.Body).ReadToEndAsync();
+            Pins pinData = JsonSerializer.Deserialize<Pins>(pinsText);
+
+            // Sometimes the update gets called periodically as pin progress updates via playing,
+            // may not affect equipped profile pins however, so check before setting it.
+            string currentPins = user.Pins;
+            string newPins = string.Join(",", pinData.profile_pins);
+            if (!String.Equals(currentPins,newPins)) {
+                user.Pins = newPins;
+                await this.database.SaveChangesAsync();
+            }
+            return this.Ok("[{\"StatusCode\":200}]");
         }
     }
 }

--- a/ProjectLighthouse/Controllers/UserController.cs
+++ b/ProjectLighthouse/Controllers/UserController.cs
@@ -131,7 +131,6 @@ namespace LBPUnion.ProjectLighthouse.Controllers
             return this.Ok();
         }
 
-        // Profile only right now
         [HttpPost("update_my_pins")]
         public async Task<IActionResult> UpdateMyPins()
         {

--- a/ProjectLighthouse/Types/Profiles/Pins.cs
+++ b/ProjectLighthouse/Types/Profiles/Pins.cs
@@ -1,12 +1,14 @@
-using LBPUnion.ProjectLighthouse.Serialization;
-
+using System.Text.Json.Serialization;
 namespace LBPUnion.ProjectLighthouse.Types.Profiles
 {
     public class Pins
     {
-        public long[] progress { get; set; }
-        public long[] awards { get; set; }
-        public long[] profile_pins { get; set; }
+        [JsonPropertyName("progress")]
+        public long[] Progress { get; set; }
+        [JsonPropertyName("awards")]
+        public long[] Awards { get; set; }
+        [JsonPropertyName("profile_pins")]
+        public long[] ProfilePins { get; set; }
     }
 }
 

--- a/ProjectLighthouse/Types/Profiles/Pins.cs
+++ b/ProjectLighthouse/Types/Profiles/Pins.cs
@@ -1,0 +1,12 @@
+using LBPUnion.ProjectLighthouse.Serialization;
+
+namespace LBPUnion.ProjectLighthouse.Types.Profiles
+{
+    public class Pins
+    {
+        public long[] progress { get; set; }
+        public long[] awards { get; set; }
+        public long[] profile_pins { get; set; }
+    }
+}
+


### PR DESCRIPTION
Adds support for setting profile pins.

### Some notes:
- Tested in LBP2, RPCS3 environment
- Added a new class under Profile in Types for "Pins", because I needed a class in order to deserialize the JSON request body being posted. Hopefully this is the appropriate place to put it.
- If there is a better way to grab the profile_pins key from the `update_my_pins` request without the Pins class, or the class needs more (like the `Serialize` method or xml attributes seen in other "Types"), please let me know. I'm familiarizing myself with C# so I picked a relatively simple task to undertake.
- I'm not sure if the progress and awards fields are used for online play because the `profile_pins` are what's being set in the actual profile. No database changes are needed for my additions because the joined `profile_pins` string is being set in `User.Pins`