### PR TITLE
Add support for level ratings

### DIFF
--- a/ProjectLighthouse/Controllers/ReviewController.cs
+++ b/ProjectLighthouse/Controllers/ReviewController.cs
@@ -1,0 +1,48 @@
+#nullable enable
+using System;
+using System.Threading.Tasks;
+using LBPUnion.ProjectLighthouse.Types;
+using LBPUnion.ProjectLighthouse.Types.Levels;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace LBPUnion.ProjectLighthouse.Controllers
+{
+    [ApiController]
+    [Route("LITTLEBIGPLANETPS3_XML/")]
+    [Produces("text/plain")]
+    public class ReviewController : ControllerBase
+    {
+        private readonly Database database;
+
+        public ReviewController(Database database)
+        {
+            this.database = database;
+        }
+
+        [HttpPost("dpadrate/user/{slotId}")]
+        public async Task<IActionResult> DPadRate(int slotId, [FromQuery] int rating)
+        {
+            User? user = await this.database.UserFromRequest(this.Request);
+            if (user == null) return this.StatusCode(403, "");
+
+            Slot? slot = await this.database.Slots.FirstOrDefaultAsync(s => s.SlotId == slotId);
+            if (slot == null) return this.StatusCode(403, "");
+
+            RatedLevel? ratedLevel = await this.database.RatedLevels.FirstOrDefaultAsync(r => r.SlotId == slotId && r.UserId == user.UserId);
+            if (ratedLevel == null)
+            {
+                ratedLevel = new();
+                this.database.RatedLevels.Add(ratedLevel);
+            }
+            ratedLevel.SlotId = slotId;
+            ratedLevel.UserId = user.UserId;
+            ratedLevel.Rating = rating;
+            // Unsupported: ratedLevel.LBP1Rating
+
+            await this.database.SaveChangesAsync();
+
+            return this.Ok();
+        }
+    }
+}

--- a/ProjectLighthouse/Controllers/SlotsController.cs
+++ b/ProjectLighthouse/Controllers/SlotsController.cs
@@ -61,12 +61,8 @@ namespace LBPUnion.ProjectLighthouse.Controllers
             if (slot == null) return this.NotFound();
 
             RatedLevel? ratedLevel = await this.database.RatedLevels.FirstOrDefaultAsync(r => r.SlotId == id && r.UserId == user.UserId);
-            if (ratedLevel != null) {
-                slot.YourRating = ratedLevel.RatingLBP1;
-                slot.YourDPadRating = ratedLevel.Rating;
-            }
-            
-            return this.Ok(slot.Serialize());
+            string res = ratedLevel != null ? slot.Serialize(ratedLevel.RatingLBP1, ratedLevel.Rating) : slot.Serialize();
+            return this.Ok(res);
         }
 
         [HttpGet("slots/lbp2cool")]

--- a/ProjectLighthouse/Database.cs
+++ b/ProjectLighthouse/Database.cs
@@ -27,6 +27,7 @@ namespace LBPUnion.ProjectLighthouse
         public DbSet<Photo> Photos { get; set; }
         public DbSet<LastMatch> LastMatches { get; set; }
         public DbSet<VisitedLevel> VisitedLevels { get; set; }
+        public DbSet<RatedLevel> RatedLevels { get; set; }
 
         protected override void OnConfiguring(DbContextOptionsBuilder options)
             => options.UseMySql(ServerSettings.DbConnectionString, MySqlServerVersion.LatestSupportedServerVersion);

--- a/ProjectLighthouse/Migrations/20211108212022_BooYayRateLevels.Designer.cs
+++ b/ProjectLighthouse/Migrations/20211108212022_BooYayRateLevels.Designer.cs
@@ -2,14 +2,16 @@
 using LBPUnion.ProjectLighthouse;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace ProjectLighthouse.Migrations
 {
     [DbContext(typeof(Database))]
-    partial class DatabaseModelSnapshot : ModelSnapshot
+    [Migration("20211108212022_BooYayRateLevels")]
+    partial class BooYayRateLevels
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ProjectLighthouse/Migrations/20211108212022_BooYayRateLevels.cs
+++ b/ProjectLighthouse/Migrations/20211108212022_BooYayRateLevels.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace ProjectLighthouse.Migrations
+{
+    public partial class BooYayRateLevels : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "RatedLevels",
+                columns: table => new
+                {
+                    RatedLevelId = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    UserId = table.Column<int>(type: "int", nullable: false),
+                    SlotId = table.Column<int>(type: "int", nullable: false),
+                    Rating = table.Column<int>(type: "int", nullable: false),
+                    RatingLBP1 = table.Column<double>(type: "double", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RatedLevels", x => x.RatedLevelId);
+                    table.ForeignKey(
+                        name: "FK_RatedLevels_Slots_SlotId",
+                        column: x => x.SlotId,
+                        principalTable: "Slots",
+                        principalColumn: "SlotId",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_RatedLevels_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "UserId",
+                        onDelete: ReferentialAction.Cascade);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RatedLevels_SlotId",
+                table: "RatedLevels",
+                column: "SlotId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RatedLevels_UserId",
+                table: "RatedLevels",
+                column: "UserId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "RatedLevels");
+        }
+    }
+}

--- a/ProjectLighthouse/Types/Levels/RatedLevel.cs
+++ b/ProjectLighthouse/Types/Levels/RatedLevel.cs
@@ -1,0 +1,26 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace LBPUnion.ProjectLighthouse.Types.Levels
+{
+    public class RatedLevel
+    {
+        // ReSharper disable once UnusedMember.Global
+        [Key]
+        public int RatedLevelId { get; set; }
+
+        public int UserId { get; set; }
+
+        [ForeignKey(nameof(UserId))]
+        public User User { get; set; }
+
+        public int SlotId { get; set; }
+
+        [ForeignKey(nameof(SlotId))]
+        public Slot Slot { get; set; }
+
+        public int Rating { get; set; }
+
+        public double RatingLBP1 { get; set; }
+    }
+}

--- a/ProjectLighthouse/Types/Levels/Slot.cs
+++ b/ProjectLighthouse/Types/Levels/Slot.cs
@@ -175,28 +175,12 @@ namespace LBPUnion.ProjectLighthouse.Types.Levels
             }
         }
 
-        [NotMapped]
-        [XmlElement("yourRating")]
-        public double YourRating { get; set; }
-
-        [NotMapped]
-        [XmlElement("yourDPadRating")]
-        public int YourDPadRating { get; set; }
-
-        [NotMapped]
-        [XmlElement("yourLBP1PlayCount")]
-        public int YourLBP1PlayCount { get; set; }
-
-        [NotMapped]
-        [XmlElement("yourLBP2PlayCount")]
-        public int YourLBP2PlayCount { get; set; }
-
         public string SerializeResources()
         {
             return this.Resources.Aggregate("", (current, resource) => current + LbpSerializer.StringElement("resource", resource));
         }
 
-        public string Serialize()
+        public string Serialize(double? yourRating = null, int? yourDPadRating = null, int? yourLBP1PlayCount = null, int? yourLBP2PlayCount = null)
         {
             string slotData = LbpSerializer.StringElement("name", this.Name) +
                               LbpSerializer.StringElement("id", this.SlotId) +
@@ -233,11 +217,11 @@ namespace LBPUnion.ProjectLighthouse.Types.Levels
                               LbpSerializer.StringElement("lbp3UniquePlayCount", this.PlaysLBP3Unique) +
                               LbpSerializer.StringElement("thumbsup", this.Thumbsup) +
                               LbpSerializer.StringElement("thumbsdown", this.Thumbsdown) +
-                              LbpSerializer.StringElement("yourRating", this.YourRating) +
-                              LbpSerializer.StringElement("yourDPadRating", this.YourDPadRating) +
-                              LbpSerializer.StringElement("yourLBP1PlayCount", this.YourLBP1PlayCount) +
-                              LbpSerializer.StringElement("yourLBP2PlayCount", this.YourLBP2PlayCount) +
-                              LbpSerializer.StringElement("averageRating", this.RatingLBP1);
+                              LbpSerializer.StringElement("averageRating", this.RatingLBP1) +
+                              yourRating        != null ? LbpSerializer.StringElement("yourRating", yourRating) : "" +
+                              yourDPadRating    != null ? LbpSerializer.StringElement("yourDPadRating", yourDPadRating) : "" +
+                              yourLBP1PlayCount != null ? LbpSerializer.StringElement("yourLBP1PlayCount", yourLBP1PlayCount) : "" +
+                              yourLBP2PlayCount != null ? LbpSerializer.StringElement("yourLBP2PlayCount", yourLBP2PlayCount) : "";
 
             return LbpSerializer.TaggedStringElement("slot", slotData, "type", "user");
         }

--- a/ProjectLighthouse/Types/Levels/Slot.cs
+++ b/ProjectLighthouse/Types/Levels/Slot.cs
@@ -139,7 +139,37 @@ namespace LBPUnion.ProjectLighthouse.Types.Levels
         [XmlIgnore]
         public int PlaysLBP3Unique { get; set; }
 
-        
+        [XmlElement("thumbsup")]
+        public int Thumbsup
+        {
+            get
+            {
+                using Database database = new();
+
+                return database.RatedLevels.Count(r => r.SlotId == this.SlotId && r.Rating == 1);
+            }
+        }
+        [XmlElement("thumbsdown")]
+        public int Thumbsdown
+        {
+            get
+            {
+                using Database database = new();
+
+                return database.RatedLevels.Count(r => r.SlotId == this.SlotId && r.Rating == -1);
+            }
+        }
+        [XmlElement("averageRating")]
+        public double RatingLBP1 { get {
+                using Database database = new();
+
+                IQueryable<RatedLevel> ratedLevels = database.RatedLevels.Where(r => r.SlotId == this.SlotId && r.RatingLBP1 > 0);
+                if (!ratedLevels.Any()) return 3.0;
+
+                return Enumerable.Average(ratedLevels, r => r.RatingLBP1); ;
+            } 
+        } 
+
         public string SerializeResources()
         {
             return this.Resources.Aggregate("", (current, resource) => current + LbpSerializer.StringElement("resource", resource));
@@ -179,7 +209,10 @@ namespace LBPUnion.ProjectLighthouse.Types.Levels
                               LbpSerializer.StringElement("lbp2UniquePlayCount", this.PlaysLBP2Unique) + // not actually used ingame, as per above comment
                               LbpSerializer.StringElement("lbp3PlayCount", this.PlaysLBP3) +
                               LbpSerializer.StringElement("lbp3CompletionCount", this.PlaysLBP3Complete) +
-                              LbpSerializer.StringElement("lbp3UniquePlayCount", this.PlaysLBP3Unique);
+                              LbpSerializer.StringElement("lbp3UniquePlayCount", this.PlaysLBP3Unique) +
+                              LbpSerializer.StringElement("thumbsup", this.Thumbsup) +
+                              LbpSerializer.StringElement("thumbsdown", this.Thumbsdown) +
+                              LbpSerializer.StringElement("averageRating", this.RatingLBP1);
 
             return LbpSerializer.TaggedStringElement("slot", slotData, "type", "user");
         }

--- a/ProjectLighthouse/Types/Levels/Slot.cs
+++ b/ProjectLighthouse/Types/Levels/Slot.cs
@@ -139,6 +139,7 @@ namespace LBPUnion.ProjectLighthouse.Types.Levels
         [XmlIgnore]
         public int PlaysLBP3Unique { get; set; }
 
+        [NotMapped]
         [XmlElement("thumbsup")]
         public int Thumbsup
         {
@@ -149,6 +150,8 @@ namespace LBPUnion.ProjectLighthouse.Types.Levels
                 return database.RatedLevels.Count(r => r.SlotId == this.SlotId && r.Rating == 1);
             }
         }
+
+        [NotMapped]
         [XmlElement("thumbsdown")]
         public int Thumbsdown
         {
@@ -159,6 +162,8 @@ namespace LBPUnion.ProjectLighthouse.Types.Levels
                 return database.RatedLevels.Count(r => r.SlotId == this.SlotId && r.Rating == -1);
             }
         }
+
+        [NotMapped]
         [XmlElement("averageRating")]
         public double RatingLBP1 { get {
                 using Database database = new();
@@ -167,8 +172,24 @@ namespace LBPUnion.ProjectLighthouse.Types.Levels
                 if (!ratedLevels.Any()) return 3.0;
 
                 return Enumerable.Average(ratedLevels, r => r.RatingLBP1); ;
-            } 
-        } 
+            }
+        }
+
+        [NotMapped]
+        [XmlElement("yourRating")]
+        public double YourRating { get; set; }
+
+        [NotMapped]
+        [XmlElement("yourDPadRating")]
+        public int YourDPadRating { get; set; }
+
+        [NotMapped]
+        [XmlElement("yourLBP1PlayCount")]
+        public int YourLBP1PlayCount { get; set; }
+
+        [NotMapped]
+        [XmlElement("yourLBP2PlayCount")]
+        public int YourLBP2PlayCount { get; set; }
 
         public string SerializeResources()
         {
@@ -212,6 +233,10 @@ namespace LBPUnion.ProjectLighthouse.Types.Levels
                               LbpSerializer.StringElement("lbp3UniquePlayCount", this.PlaysLBP3Unique) +
                               LbpSerializer.StringElement("thumbsup", this.Thumbsup) +
                               LbpSerializer.StringElement("thumbsdown", this.Thumbsdown) +
+                              LbpSerializer.StringElement("yourRating", this.YourRating) +
+                              LbpSerializer.StringElement("yourDPadRating", this.YourDPadRating) +
+                              LbpSerializer.StringElement("yourLBP1PlayCount", this.YourLBP1PlayCount) +
+                              LbpSerializer.StringElement("yourLBP2PlayCount", this.YourLBP2PlayCount) +
                               LbpSerializer.StringElement("averageRating", this.RatingLBP1);
 
             return LbpSerializer.TaggedStringElement("slot", slotData, "type", "user");


### PR DESCRIPTION
Self explanatory, lets a user Yay and Boo levels, as well as send a 5 star rating of a level in LBP1. 

A user that has played a level in both LBP1 and LBP2+ can simultaneously yay/boo a level and have a numeric LBP1 rating associated to them.