### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,6 @@ Some modifications may require updates to the database schema. You can automatic
 | LBP1     | Compatible                          | Incompatible, crashes on entering pod computer | N/A                |
 | LBP2     | Compatible                          | Compatible with patched RPCS3                  | N/A                |
 | LBP3     | Somewhat compatible                 | Somewhat compatible with workaround            | Incompatible       |
-| LBP Vita | Somewhat compatible with workaround | N/A                                            | N/A                |
+| LBP Vita | Compatible | N/A                                            | N/A                |
 
 Project Lighthouse is still a heavy work in progress, so this is subject to change at any point.


### PR DESCRIPTION
change lbp vita in the compatibility list thingy from 'somewhat compatible with workaround' to 'compatible' because it works about as well as LBP2 and does not require any workaround other than using a different digest key (than the mainline games), but i would not call that a workaround.