### PR TITLE
(Website) View location of photo subjects in photo

### DIFF
--- a/ProjectLighthouse/Pages/Layouts/BaseLayout.cshtml
+++ b/ProjectLighthouse/Pages/Layouts/BaseLayout.cshtml
@@ -64,6 +64,17 @@
             gtag('config', '@ServerSettings.Instance.GoogleAnalyticsId');
         </script>
     }
+
+    <style>
+        canvas.photo-subjects {
+            opacity: 1;
+            transition: opacity 0.3s;
+        }
+
+        canvas.hide-subjects {
+            opacity: 0;
+        }
+    </style>
 </head>
 <body>
 <div class="pageContainer">

--- a/ProjectLighthouse/Pages/Layouts/BaseLayout.cshtml
+++ b/ProjectLighthouse/Pages/Layouts/BaseLayout.cshtml
@@ -64,17 +64,6 @@
             gtag('config', '@ServerSettings.Instance.GoogleAnalyticsId');
         </script>
     }
-
-    <style>
-        canvas.photo-subjects {
-            opacity: 1;
-            transition: opacity 0.3s;
-        }
-
-        canvas.hide-subjects {
-            opacity: 0;
-        }
-    </style>
 </head>
 <body>
 <div class="pageContainer">

--- a/ProjectLighthouse/Pages/Partials/PhotoPartial.cshtml
+++ b/ProjectLighthouse/Pages/Partials/PhotoPartial.cshtml
@@ -33,9 +33,8 @@
 
 
 <script>
-    // set timeout so that the image heights have been calculated
-    // (after document renders)
-    window.setTimeout(function () {
+    // render the page first so that image heights have been calculated
+    window.addEventListener("load", function () {
         var canvas = document.getElementById("canvas-subjects-@Model.PhotoId");
 
         const hoverer = document.getElementById("hover-subjects-@Model.PhotoId");
@@ -123,5 +122,5 @@
             // reset transform
             context.setTransform(1, 0, 0, 1, 0, 0);
         })
-    }, 100)
+    }, false);
 </script>

--- a/ProjectLighthouse/Pages/Partials/PhotoPartial.cshtml
+++ b/ProjectLighthouse/Pages/Partials/PhotoPartial.cshtml
@@ -6,7 +6,7 @@
 
 <div style="position: relative">
     <canvas class="hide-subjects" id="canvas-subjects-@Model.PhotoId" width="1920" height="1080"
-        style="position: absolute; /*width: 100%; height: 100%;*/ transform: rotate(180deg)"></canvas>
+        style="position: absolute; transform: rotate(180deg)"></canvas>
     <img id="game-image-@Model.PhotoId" src="/gameAssets/@Model.LargeHash"
         style="width: 100%; height: auto; border-radius: .28571429rem;">
 </div>
@@ -100,16 +100,16 @@
             // Check if the label will flow off the left of the frame
             const overflowLeft = (bounds[2] * hw - tw) < (-hw);
 
+            // Set alignment
+            context.textAlign = overflowLeft ? "start" : "end";
+
             // Text x / y
             const lx = overflowLeft ? -bw + 6 : -6;
             const ly = overflowBottom ? -bh - 6 : 16;
 
             // Label background x / y
-            const lbx = overflowLeft ? -bw : -2;
+            const lbx = overflowLeft ? bw - tw - 12 : -2;
             const lby = overflowBottom ? bh : -24;
-
-            // Set alignment
-            context.textAlign = overflowLeft ? "start" : "end";
 
             // Draw background
             context.fillRect(lbx, lby, tw + 16, th);

--- a/ProjectLighthouse/Pages/Partials/PhotoPartial.cshtml
+++ b/ProjectLighthouse/Pages/Partials/PhotoPartial.cshtml
@@ -42,10 +42,10 @@
         const image = document.getElementById("game-image-@Model.PhotoId");
 
         hoverer.addEventListener('mouseenter', function () {
-            canvas.className = "photo-subjects"
+            canvas.className = "photo-subjects";
         });
         hoverer.addEventListener('mouseleave', function () {
-            canvas.className = "photo-subjects hide-subjects"
+            canvas.className = "photo-subjects hide-subjects";
         });
 
         var context = canvas.getContext('2d');
@@ -62,11 +62,11 @@
         const hw = w / 2;
         const hh = h / 2;
 
-        const colors = ["#a5599f", "#477f84", "#5fa559", "#a5595f"];
+        const colours = ["#a5599f", "#477f84", "#5fa559", "#a5595f"];
 
         subjects.forEach((s, si) => {
 
-            const colour = colors[si % 4]
+            const colour = colours[si % 4];
 
             // Bounding box
             const bounds = s.bounds.split(",").map(parseFloat);

--- a/ProjectLighthouse/Pages/Partials/PhotoPartial.cshtml
+++ b/ProjectLighthouse/Pages/Partials/PhotoPartial.cshtml
@@ -1,14 +1,13 @@
 @using LBPUnion.ProjectLighthouse.Types
-
 @model LBPUnion.ProjectLighthouse.Types.Photo
-
 
 
 <div style="position: relative">
     <canvas class="hide-subjects" id="canvas-subjects-@Model.PhotoId" width="1920" height="1080"
-        style="position: absolute; transform: rotate(180deg)"></canvas>
+            style="position: absolute; transform: rotate(180deg)">
+    </canvas>
     <img id="game-image-@Model.PhotoId" src="/gameAssets/@Model.LargeHash"
-        style="width: 100%; height: auto; border-radius: .28571429rem;">
+         style="width: 100%; height: auto; border-radius: .28571429rem;">
 </div>
 <br>
 
@@ -31,14 +30,16 @@
     }
 </div>
 
+@{
+    PhotoSubject[] subjects = Model.Subjects.ToArray();
+    foreach (PhotoSubject subject in subjects) subject.Username = subject.User.Username;
+}
 
 <script>
     // render the page first so that image heights have been calculated
     window.addEventListener("load", function () {
-        var canvas = document.getElementById("canvas-subjects-@Model.PhotoId");
-
+        const canvas = document.getElementById("canvas-subjects-@Model.PhotoId");
         const hoverer = document.getElementById("hover-subjects-@Model.PhotoId");
-
         const image = document.getElementById("game-image-@Model.PhotoId");
 
         hoverer.addEventListener('mouseenter', function () {
@@ -47,10 +48,10 @@
         hoverer.addEventListener('mouseleave', function () {
             canvas.className = "photo-subjects hide-subjects";
         });
+        
+        const context = canvas.getContext('2d');
 
-        var context = canvas.getContext('2d');
-
-        const subjects = @Html.Raw(Json.Serialize(Model.Subjects.ToArray()));
+        const subjects = @Html.Raw(Json.Serialize(subjects.ToArray()));
 
         canvas.width = image.offsetWidth;
         canvas.height = image.clientHeight; // space for names to hang off
@@ -65,7 +66,6 @@
         const colours = ["#a5599f", "#477f84", "#5fa559", "#a5595f"];
 
         subjects.forEach((s, si) => {
-
             const colour = colours[si % 4];
 
             // Bounding box
@@ -92,7 +92,7 @@
             context.fillStyle = colour;
 
             // Text width/height for the label background
-            const tw = context.measureText(s.user.username).width;
+            const tw = context.measureText(s.username).width;
             const th = 24;
 
             // Check if the label will flow off the bottom of the frame
@@ -117,7 +117,7 @@
             // Draw text, rotated back upright (canvas draws rotated 180deg)
             context.fillStyle = "white";
             context.rotate(Math.PI);
-            context.fillText(s.user.username, lx, ly);
+            context.fillText(s.username, lx, ly);
 
             // reset transform
             context.setTransform(1, 0, 0, 1, 0, 0);

--- a/ProjectLighthouse/Pages/Partials/PhotoPartial.cshtml
+++ b/ProjectLighthouse/Pages/Partials/PhotoPartial.cshtml
@@ -1,7 +1,15 @@
 @using LBPUnion.ProjectLighthouse.Types
+
 @model LBPUnion.ProjectLighthouse.Types.Photo
 
-<img src="/gameAssets/@Model.LargeHash" style="width: 100%; height: auto; border-radius: .28571429rem;">
+
+
+<div style="position: relative">
+    <canvas class="hide-subjects" id="canvas-subjects-@Model.PhotoId" width="1920" height="1080"
+        style="position: absolute; /*width: 100%; height: 100%;*/ transform: rotate(180deg)"></canvas>
+    <img id="game-image-@Model.PhotoId" src="/gameAssets/@Model.LargeHash"
+        style="width: 100%; height: auto; border-radius: .28571429rem;">
+</div>
 <br>
 
 <p>
@@ -16,7 +24,104 @@
 <p>
     <b>Photo contains @Model.Subjects.Count @(Model.Subjects.Count == 1 ? "person" : "people"):</b>
 </p>
-@foreach (PhotoSubject subject in Model.Subjects)
-{
-    <a href="/user/@subject.UserId">@subject.User.Username</a>
-}
+<div id="hover-subjects-@Model.PhotoId">
+    @foreach (PhotoSubject subject in Model.Subjects)
+    {
+        <a href="/user/@subject.UserId">@subject.User.Username</a>
+    }
+</div>
+
+
+<script>
+    // set timeout so that the image heights have been calculated
+    // (after document renders)
+    window.setTimeout(function () {
+        var canvas = document.getElementById("canvas-subjects-@Model.PhotoId");
+
+        const hoverer = document.getElementById("hover-subjects-@Model.PhotoId");
+
+        const image = document.getElementById("game-image-@Model.PhotoId");
+
+        hoverer.addEventListener('mouseenter', function () {
+            canvas.className = "photo-subjects"
+        });
+        hoverer.addEventListener('mouseleave', function () {
+            canvas.className = "photo-subjects hide-subjects"
+        });
+
+        var context = canvas.getContext('2d');
+
+        const subjects = @Html.Raw(Json.Serialize(Model.Subjects.ToArray()));
+
+        canvas.width = image.offsetWidth;
+        canvas.height = image.clientHeight; // space for names to hang off
+
+        const w = canvas.width;
+        const h = canvas.height;
+
+        // halfwidth, halfheight
+        const hw = w / 2;
+        const hh = h / 2;
+
+        const colors = ["#a5599f", "#477f84", "#5fa559", "#a5595f"];
+
+        subjects.forEach((s, si) => {
+
+            const colour = colors[si % 4]
+
+            // Bounding box
+            const bounds = s.bounds.split(",").map(parseFloat);
+
+            const [x1, y1, x2, y2] = bounds.map(n => Math.min(Math.max(n, -1), 1));
+
+            const bx = hw - (x2 * hw);
+            const by = hh - (y2 * hh);
+            const bw = (x2 - x1) * hw;
+            const bh = (y2 - y1) * hh;
+
+            context.beginPath();
+            context.lineWidth = 3;
+            context.strokeStyle = colour;
+            context.rect(bx, by, bw, bh);
+            context.stroke();
+
+            // Move into relative coordinates from bounding box
+            context.translate(bx, by);
+
+            // Username label
+            context.font = "16px Arial";
+            context.fillStyle = colour;
+
+            // Text width/height for the label background
+            const tw = context.measureText(s.user.username).width;
+            const th = 24;
+
+            // Check if the label will flow off the bottom of the frame
+            const overflowBottom = (bounds[3] * hh) > (hh - 24);
+            // Check if the label will flow off the left of the frame
+            const overflowLeft = (bounds[2] * hw - tw) < (-hw);
+
+            // Text x / y
+            const lx = overflowLeft ? -bw + 6 : -6;
+            const ly = overflowBottom ? -bh - 6 : 16;
+
+            // Label background x / y
+            const lbx = overflowLeft ? -bw : -2;
+            const lby = overflowBottom ? bh : -24;
+
+            // Set alignment
+            context.textAlign = overflowLeft ? "start" : "end";
+
+            // Draw background
+            context.fillRect(lbx, lby, tw + 16, th);
+
+            // Draw text, rotated back upright (canvas draws rotated 180deg)
+            context.fillStyle = "white";
+            context.rotate(Math.PI);
+            context.fillText(s.user.username, lx, ly);
+
+            // reset transform
+            context.setTransform(1, 0, 0, 1, 0, 0);
+        })
+    }, 100)
+</script>

--- a/ProjectLighthouse/StaticFiles/css/styles.css
+++ b/ProjectLighthouse/StaticFiles/css/styles.css
@@ -16,3 +16,12 @@ div.statsUnderTitle > span {
     margin-right: 5px;
 }
 
+canvas.photo-subjects {
+    opacity: 1;
+    transition: opacity 0.3s;
+}
+
+canvas.hide-subjects {
+    opacity: 0;
+}
+

--- a/ProjectLighthouse/StaticFiles/css/styles.css
+++ b/ProjectLighthouse/StaticFiles/css/styles.css
@@ -16,12 +16,3 @@ div.statsUnderTitle > span {
     margin-right: 5px;
 }
 
-canvas.photo-subjects {
-    opacity: 1;
-    transition: opacity 0.3s;
-}
-
-canvas.hide-subjects {
-    opacity: 0;
-}
-

--- a/ProjectLighthouse/Types/PhotoSubject.cs
+++ b/ProjectLighthouse/Types/PhotoSubject.cs
@@ -1,6 +1,7 @@
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json.Serialization;
 using System.Xml.Serialization;
 using LBPUnion.ProjectLighthouse.Serialization;
 
@@ -20,6 +21,7 @@ namespace LBPUnion.ProjectLighthouse.Types
 
         [XmlIgnore]
         [ForeignKey(nameof(UserId))]
+        [JsonIgnore]
         public User User { get; set; }
 
         [NotMapped]


### PR DESCRIPTION
This is a feature proposal that could possibly close #91 if approved.

I have implemented a simple JS+HTML Canvas username label+boundary renderer to allow anyone to view the location of photo subjects within a photo, through the main website.

[demo gif](https://media.discordapp.net/attachments/915460867506712637/921616288005120100/Peek_2021-12-17_23-02.gif?width=1067&height=686)

Subject bounds are hidden by default, requiring the user to hover over the subject list to view them. Furthermore, labels will move to stay within the frame if they were to render outside the canvas.

Here is a quick screenshot showing off the colour (multiple players) and label shifting functionality.

![image](https://user-images.githubusercontent.com/7350336/146629936-09685181-3d4d-4a03-ba74-5091b80f854f.png)

### Notes
- This feature works site-wide, as long as the photo is rendered as a `PhotoPartial`. Labels and their text will maintain their absolute scale on the page (so that it's still possible to read the label when there's a small `PhotoPartial`
- The labels will not shift to avoid each other -- overlap is possible if many players are packed close
  - this is due to the fact that the labels are all drawn to the same canvas. It's possible to draw a canvas for each label but it may lead to performance issues or require a rework of logic. Coding collision logic between labels seemed too out of scope for the scale of this feature, but maybe we'll see?

TLDR: This approach adds a canvas overlay to each `PhotoPartial` that renders subjects and their locations using the HTML canvas.